### PR TITLE
Running hard delete after all other tasks

### DIFF
--- a/cleanup-job.sh
+++ b/cleanup-job.sh
@@ -53,7 +53,7 @@ function escape_url {
 
 function run_final_cleanup {
     #  Triggering  needed tasks including hard cleanup task.
-    last=${#@}
+    last=${#@};
     i=0;
     for d in "$@" ;
     do
@@ -61,12 +61,12 @@ function run_final_cleanup {
         if [ $i -eq $last ];
         then
         # optimisation needed: check the status of the previous tasks and then run the last one
-            echo "Waiting for other tasks before compacting blob store"
+            echo "Waiting for other tasks before compacting blob store";
             sleep 300;
-            echo "Running Task with ID $d"
+            echo "Running Task with ID $d";
             curl -i -u ${NEXUS_AUTH} -X POST "${NEXUS_URL}/service/rest/v1/tasks/$d/run" -H "accept: application/json";
         else
-            echo "Running Task with ID $d"
+            echo "Running Task with ID $d";
             curl -i -u ${NEXUS_AUTH} -X POST "${NEXUS_URL}/service/rest/v1/tasks/$d/run" -H "accept: application/json";
         fi
     done

--- a/cleanup-job.sh
+++ b/cleanup-job.sh
@@ -53,10 +53,22 @@ function escape_url {
 
 function run_final_cleanup {
     #  Triggering  needed tasks including hard cleanup task.
-    for i in "$@" ;
+    last=${#@}
+    i=0;
+    for d in "$@" ;
     do
-        echo "Running Task with ID $i"
-        curl -i -u ${NEXUS_AUTH} -X POST "${NEXUS_URL}/service/rest/v1/tasks/$i/run" -H "accept: application/json";
+        i=$((i+1));
+        if [ $i -eq $last ];
+        then
+        # optimisation needed: check the status of the previous tasks and then run the last one
+            echo "Waiting for other tasks before compacting blob store"
+            sleep 300;
+            echo "Running Task with ID $d"
+            curl -i -u ${NEXUS_AUTH} -X POST "${NEXUS_URL}/service/rest/v1/tasks/$d/run" -H "accept: application/json";
+        else
+            echo "Running Task with ID $d"
+            curl -i -u ${NEXUS_AUTH} -X POST "${NEXUS_URL}/service/rest/v1/tasks/$d/run" -H "accept: application/json";
+        fi
     done
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Since the call to run tasks run one after the other, there could be a situation when the first tasks will run while `compact blob store` (hard delete). I believe this can cause issues that I want to avoid so I added a delay to allow all other tasks to finish before hard delete start. I would prefer to optimise it to start the last task only after the other tasks are done but this will be a good optimisation for the future.
**Special notes for your reviewer**:

**If applicable**:
- [X] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
