### PR TITLE
add-an-option-to-cleanup-artefacts-that-werent-downloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Each set of `-p` parameters will create the following type of query :
 ```
 SELECT * FROM asset WHERE name MATCHES '[regex_for_db]' AND [date_query_field] < [current_date - days]
 ```
-** UPDATE: When using `last_downloaded` as [date_query_field] , the script until now didn't delete artifacts that weren't never downloaded ( Null field wasn't included in the query). From now, by adding another cleanup task with [not_downloaded] set to `true` on the script in the `-p` argument, The tool will create a cleanup task that will use the following DB query:
+** UPDATE: When using `last_downloaded` as [date_query_field] , the script until now didn't delete artefacts that were never downloaded ( Null field wasn't included in the query). From now, by adding another cleanup task with [not_downloaded] set to `true` on the script in the `-p` argument, The tool will create a cleanup task that will use the following DB query:
 ```
 SELECT * FROM asset WHERE blob_updated < [current_date - days] AND name MATCHES '[regex_for_db]' AND last_downloaded IS NULL
 ```
-The [days] argument will be used for limiting the non downloaded artifacts to ones that were only updated before [days] days.
+The [days] argument will be used for limiting the non downloaded artefacts to ones that were only updated before [days] days.
 __*Setting up tasks to run after cleanup (-t)*__
 
 Argument `-t` is meant to be trigger Nexus pre-configured tasks after the custom cleanup. This tasks should be configured manually in Nexus, and their ID should be passed to the image.

--- a/cleanup-job.sh
+++ b/cleanup-job.sh
@@ -70,7 +70,7 @@ function run_final_cleanup {
                 status=$(curl -i -u ${NEXUS_AUTH} -X GET "${NEXUS_URL}/service/rest/v1/tasks/$prevtask" -H "accept: application/json" | grep -Eo '"currentState" : "[A-Z]*"' | sed -e 's/"currentState" : //');
                 echo "Status is $status"
                 if [ $status == '"RUNNING"' ]; then
-                    sleeptime=$((5*60));
+                    sleeptime=$((5*60));  # wait for 5 minutes until next status check
                     sleep ${sleeptime};
                 else
                     echo "Running Task with ID $d";

--- a/cleanup-job.sh
+++ b/cleanup-job.sh
@@ -41,7 +41,7 @@ function delete_script {
 
 
 function adjust_dates {
-    local d;   
+    local d;
     d=$(date --date='-'${1}' day' +%Y-%m-%d)
     echo "$d"
 }
@@ -77,10 +77,16 @@ function create_curl {
     DATE=$(adjust_dates ${1});
     URL=$(escape_url ${2});
     TIMEFILTER="${3}";
-    curl -i -u ${NEXUS_AUTH} -X POST "${NEXUS_URL}/service/rest/v1/script/dockerCleanup/run" -H "accept: application/json" -H "Content-Type: text/plain" -d "{\"repoName\":\"${NEXUS_REPO}\",\"startDate\":\"${DATE}\",\"url\":\"${URL}\",\"timeFilter\":\"${TIMEFILTER}\"}"
+    if [ -z "${4}" ]
+    then
+        NOTDOWNLOADED="false"
+    else
+        NOTDOWNLOADED="${4}"
+    fi
+    curl -i -u ${NEXUS_AUTH} -X POST "${NEXUS_URL}/service/rest/v1/script/dockerCleanup/run" -H "accept: application/json" -H "Content-Type: text/plain" -d "{\"repoName\":\"${NEXUS_REPO}\",\"startDate\":\"${DATE}\",\"url\":\"${URL}\",\"timeFilter\":\"${TIMEFILTER}\",\"notDownloaded\":\"${NOTDOWNLOADED}\"}"
 }
 
-
+delete_script;
 echo "==> Loading Cleanup script" & load_script;
 echo "==> Running Custom Cleanup";
 while getopts ":p:t:h" opt; do
@@ -88,7 +94,7 @@ while getopts ":p:t:h" opt; do
         p ) set -f # disable glob
             IFS=' ' # split on space characters
             array=($OPTARG)  # use the split+glob operator
-            if [ "${#array[@]}" = 3 ] ;
+            if [ "${#array[@]}" = 3 ]|| [ "${#array[@]}" = 4 ] ;
             then
                 create_curl ${array[@]}
             else
@@ -104,6 +110,6 @@ while getopts ":p:t:h" opt; do
     esac
 done
 
-echo "==> Running final Cleanup" 
+echo "==> Running final Cleanup"
 run_final_cleanup ${tasks[@]}
 printf "\n Cleanup Ended succesfully!"

--- a/cleanup-job.sh
+++ b/cleanup-job.sh
@@ -70,13 +70,14 @@ function run_final_cleanup {
                 status=$(curl -i -u ${NEXUS_AUTH} -X GET "${NEXUS_URL}/service/rest/v1/tasks/$prevtask" -H "accept: application/json" | grep -Eo '"currentState" : "[A-Z]*"' | sed -e 's/"currentState" : //');
                 echo "Status is $status"
                 if [ $status == '"RUNNING"' ]; then
-                    sleeptime=$((5*60));  # wait for 5 minutes until next status check
+                    sleeptime=$((1*60));  # wait for 5 minutes until next status check
                     sleep ${sleeptime};
                 else
                     echo "Running Task with ID $d";
                     curl -i -u ${NEXUS_AUTH} -X POST "${NEXUS_URL}/service/rest/v1/tasks/$d/run" -H "accept: application/json";
                     prevtask=$d
                     status='"RUNNING"'
+                    break;
                 fi
             done
         fi
@@ -97,20 +98,21 @@ function create_curl {
     curl -i -u ${NEXUS_AUTH} -X POST "${NEXUS_URL}/service/rest/v1/script/dockerCleanup/run" -H "accept: application/json" -H "Content-Type: text/plain" -d "{\"repoName\":\"${NEXUS_REPO}\",\"startDate\":\"${DATE}\",\"url\":\"${URL}\",\"timeFilter\":\"${TIMEFILTER}\",\"notDownloaded\":\"${NOTDOWNLOADED}\"}"
 }
 
-delete_script;
-echo "==> Loading Cleanup script" & load_script;
+# delete_script;
+# echo "==> Loading Cleanup script" & load_script;
 echo "==> Running Custom Cleanup";
 while getopts ":p:t:h" opt; do
     case $opt in
-        p ) set -f # disable glob
-            IFS=' ' # split on space characters
-            array=($OPTARG)  # use the split+glob operator
-            if [ "${#array[@]}" = 3 ]|| [ "${#array[@]}" = 4 ] ;
-            then
-                create_curl ${array[@]}
-            else
-                echo  "${array[@]} is not valid, please have 3 parameters per query seperated by space ,/n format \"1 '^v2\/.*\/cache\/.*$' 'blob_created' \" "
-            fi;;
+        p ) echo "no p";;
+        # p ) set -f # disable glob
+        #     IFS=' ' # split on space characters
+        #     array=($OPTARG)  # use the split+glob operator
+        #     if [ "${#array[@]}" = 3 ]|| [ "${#array[@]}" = 4 ] ;
+        #     then
+        #         create_curl ${array[@]}
+        #     else
+        #         echo  "${array[@]} is not valid, please have 3 parameters per query seperated by space ,/n format \"1 '^v2\/.*\/cache\/.*$' 'blob_created' \" "
+        #     fi;;
         t ) set -f # disable glob
             IFS=' ' # split on space characters
             tasks=($OPTARG) ;; # use the split+glob operator

--- a/cleanup-job.sh
+++ b/cleanup-job.sh
@@ -70,7 +70,7 @@ function run_final_cleanup {
                 status=$(curl -i -u ${NEXUS_AUTH} -X GET "${NEXUS_URL}/service/rest/v1/tasks/$prevtask" -H "accept: application/json" | grep -Eo '"currentState" : "[A-Z]*"' | sed -e 's/"currentState" : //');
                 echo "Status is $status"
                 if [ $status == '"RUNNING"' ]; then
-                    sleeptime=$((1*60));  # wait for 5 minutes until next status check
+                    sleeptime=$((5*60));  # wait for 5 minutes until next status check
                     sleep ${sleeptime};
                 else
                     echo "Running Task with ID $d";
@@ -98,21 +98,20 @@ function create_curl {
     curl -i -u ${NEXUS_AUTH} -X POST "${NEXUS_URL}/service/rest/v1/script/dockerCleanup/run" -H "accept: application/json" -H "Content-Type: text/plain" -d "{\"repoName\":\"${NEXUS_REPO}\",\"startDate\":\"${DATE}\",\"url\":\"${URL}\",\"timeFilter\":\"${TIMEFILTER}\",\"notDownloaded\":\"${NOTDOWNLOADED}\"}"
 }
 
-# delete_script;
-# echo "==> Loading Cleanup script" & load_script;
+delete_script;
+echo "==> Loading Cleanup script" & load_script;
 echo "==> Running Custom Cleanup";
 while getopts ":p:t:h" opt; do
     case $opt in
-        p ) echo "no p";;
-        # p ) set -f # disable glob
-        #     IFS=' ' # split on space characters
-        #     array=($OPTARG)  # use the split+glob operator
-        #     if [ "${#array[@]}" = 3 ]|| [ "${#array[@]}" = 4 ] ;
-        #     then
-        #         create_curl ${array[@]}
-        #     else
-        #         echo  "${array[@]} is not valid, please have 3 parameters per query seperated by space ,/n format \"1 '^v2\/.*\/cache\/.*$' 'blob_created' \" "
-        #     fi;;
+        p ) set -f # disable glob
+            IFS=' ' # split on space characters
+            array=($OPTARG)  # use the split+glob operator
+            if [ "${#array[@]}" = 3 ]|| [ "${#array[@]}" = 4 ] ;
+            then
+                create_curl ${array[@]}
+            else
+                echo  "${array[@]} is not valid, please have 3 parameters per query seperated by space ,/n format \"1 '^v2\/.*\/cache\/.*$' 'blob_created' \" "
+            fi;;
         t ) set -f # disable glob
             IFS=' ' # split on space characters
             tasks=($OPTARG) ;; # use the split+glob operator

--- a/scripts/dockerCleanup.groovy
+++ b/scripts/dockerCleanup.groovy
@@ -7,10 +7,12 @@ import groovy.json.JsonSlurper;
 def request = new JsonSlurper().parseText(args);
 println(request);
 
+
 assert request.repoName: 'repoName parameter is required';
 assert request.startDate: 'startDate parameter is required, format: yyyy-mm-dd';
 assert request.url: 'Assest url is required, format: %/cache/%';
 assert request.timeFilter instanceof String;
+assert request.notDownloaded instanceof String;
 
 def tq = request.timeFilter.toString() + ' < ';
 def repo = repository.repositoryManager.get(request.repoName);
@@ -20,24 +22,36 @@ def urls = [];
 
 try {
     tx.begin();
-    Iterable<Asset> assets = tx.
-        findAssets(Query.builder().where(tq.toString()).param(request.startDate).and('name MATCHES').param(request.url).build(), [repo]);
-    urls = assets.collect {'/repository/'+ repo.name + '/' + it.name()};
-    assets.each { asset ->
-        log.info('Deleting asset ' + asset.name());
-        tx.deleteAsset(asset);
-        if (asset.componentId() != null) {
-            log.info('Deleting component for asset ' + asset.name());
-            def component = tx.findComponent(asset.componentId());
-            tx.deleteComponent(component);
-        }
+    Query query = new Query(String where, String suffix, Map parameters);
+    if (request.notDownloaded == 'true' && request.timeFilter == 'last_downloaded') {
+        println('notDownloaded condition is running');
+        tq = 'blob_updated < ';
+        query = Query.builder().where(tq.toString()).param(request.startDate).and('name MATCHES').param(request.url).and('last_downloaded').isNull().suffix('limit 200').build();
+    } else {
+        println('Normal condition is running');
+        query = Query.builder().where(tq.toString()).param(request.startDate).and('name MATCHES').param(request.url).suffix('limit 200').build();
     };
-    tx.commit();  
+    Iterable<Asset> assets = tx.findAssets(query, [repo]);
+    while(!assets.isEmpty()) {
+        urls << assets.collect {'/repository/'+ repo.name + '/' + it.name()};
+        assets.each { asset ->
+            log.info('Deleting asset ' + asset.name());
+            tx.deleteAsset(asset);
+            if (asset.componentId() != null) {
+                log.info('Deleting component for asset ' + asset.name());
+                def component = tx.findComponent(asset.componentId());
+                tx.deleteComponent(component);
+            };
+        };
+        assets = tx.findAssets(query, [repo]);
+    };
+    tx.commit();
     def result = JsonOutput.toJson([
         assets  : urls,
         query   : tq.toString(),
         query_term : request.url,
         before  : request.startDate,
+        notDownloaded: request.notDownloaded,
         repoName: request.repoName
     ]);
     log.info(JsonOutput.prettyPrint(result));


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

- When using `last_downloaded` as [date_query_field], the script until now didn't delete artefacts that were never downloaded ( Null field wasn't included in the query). From now, by adding another cleanup task with [not_downloaded] set to `true` on the script in the `-p` argument, The tool will create a cleanup task that will delete not downloaded artefacts with update timestamp like the one that was in[date_query_field].
- The DB cleanup will now do the deletion in bulks of 200 assets at a time in order not weigh on the DB.
- The tool will now check when running the final tasks if the previous task is done, if not, it will wait until starting the next one.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
